### PR TITLE
Remove deprecated in_memory option

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tfds
 Title: Interface to 'TensorFlow' Collection of Datasets
-Version: 0.0.0.9000
+Version: 0.0.0.9001
 Authors@R: c(
   person("Daniel", "Falbel", role = c("ctb", "cph", "cre"), email = "daniel@rstudio.com"),
   person(family = "RStudio", role = c("ctb", "cph", "fnd")),

--- a/R/load.R
+++ b/R/load.R
@@ -59,7 +59,8 @@ tfds_load <- function(name,
                       builder_kwargs = NULL,
                       download_and_prepare_kwargs = NULL,
                       as_dataset_kwargs = NULL,
-                      try_gcs = FALSE) {
+                      try_gcs = FALSE,
+                      ...) {
   ds <- tfds$load(
     name = name,
     split = split,

--- a/R/load.R
+++ b/R/load.R
@@ -16,10 +16,6 @@
 #' @param batch_size `int`, if set, add a batch dimension to examples. Note that
 #' variable length features will be 0-padded. If
 #' `batch_size=-1`, will return the full dataset as `tf.Tensor`s.
-#' @param in_memory `bool`, if `True`, loads the dataset in memory which
-#' increases iteration speeds. Note that if `True` and the dataset has
-#' unknown dimensions, the features will be padded to the maximum
-#' size across the dataset.
 #' @param download `bool` (optional), whether to call
 #' `tfds.core.DatasetBuilder.download_and_prepare`
 #' before calling `tf.DatasetBuilder.as_dataset`. If `False`, data is
@@ -48,6 +44,7 @@
 #' `tfds.core.DatasetBuilder.as_dataset`.
 #' @param try_gcs `bool`, if True, tfds.load will see if the dataset exists on
 #' the public GCS bucket before building it locally.
+#' @param ... Additional parameters, currently not used.
 #'
 #'
 #' @export
@@ -55,7 +52,6 @@ tfds_load <- function(name,
                       split = NULL,
                       data_dir = NULL,
                       batch_size = NULL,
-                      in_memory = NULL,
                       download = TRUE,
                       shuffle_files = FALSE,
                       as_supervised = FALSE,
@@ -69,7 +65,6 @@ tfds_load <- function(name,
     split = split,
     data_dir = data_dir,
     batch_size = batch_size,
-    in_memory = in_memory,
     download = download,
     shuffle_files = shuffle_files,
     as_supervised = as_supervised,
@@ -78,7 +73,8 @@ tfds_load <- function(name,
     download_and_prepare_kwargs = download_and_prepare_kwargs,
     as_dataset_kwargs = as_dataset_kwargs,
     try_gcs = try_gcs,
-    with_info = TRUE
+    with_info = TRUE,
+    ...
   )
 
   info <- ds[[length(ds)]]

--- a/man/install_tfds.Rd
+++ b/man/install_tfds.Rd
@@ -16,8 +16,8 @@ available on Windows (as this isn't supported by TensorFlow). Note also
 that since this command runs without privilege the "system" method is
 available only on Windows.}
 
-\item{conda}{Path to conda executable (or "auto" to find conda using the
-PATH and other conventional install locations).}
+\item{conda}{The path to a \code{conda} executable. Use \code{"auto"} to allow \code{reticulate} to
+automatically find an appropriate \code{conda} binary. See \strong{Finding Conda} for more details.}
 
 \item{version}{By default the latest PyPi version will be installed.
 

--- a/man/tfds_load.Rd
+++ b/man/tfds_load.Rd
@@ -5,8 +5,8 @@
 \title{Loads the named dataset into a TensorFlow Dataset}
 \usage{
 tfds_load(name, split = NULL, data_dir = NULL, batch_size = NULL,
-  in_memory = NULL, download = TRUE, shuffle_files = FALSE,
-  as_supervised = FALSE, decoders = NULL, builder_kwargs = NULL,
+  download = TRUE, shuffle_files = FALSE, as_supervised = FALSE,
+  decoders = NULL, builder_kwargs = NULL,
   download_and_prepare_kwargs = NULL, as_dataset_kwargs = NULL,
   try_gcs = FALSE)
 }
@@ -31,11 +31,6 @@ Defaults to "~/tensorflow_datasets".}
 \item{batch_size}{\code{int}, if set, add a batch dimension to examples. Note that
 variable length features will be 0-padded. If
 \code{batch_size=-1}, will return the full dataset as \code{tf.Tensor}s.}
-
-\item{in_memory}{\code{bool}, if \code{True}, loads the dataset in memory which
-increases iteration speeds. Note that if \code{True} and the dataset has
-unknown dimensions, the features will be padded to the maximum
-size across the dataset.}
 
 \item{download}{\code{bool} (optional), whether to call
 \code{tfds.core.DatasetBuilder.download_and_prepare}
@@ -72,6 +67,8 @@ cache_dir and manual_dir will automatically be deduced from data_dir.}
 
 \item{try_gcs}{\code{bool}, if True, tfds.load will see if the dataset exists on
 the public GCS bucket before building it locally.}
+
+\item{...}{Additional parameters, currently not used.}
 }
 \description{
 Loads the named dataset into a TensorFlow Dataset

--- a/man/tfds_load.Rd
+++ b/man/tfds_load.Rd
@@ -8,7 +8,7 @@ tfds_load(name, split = NULL, data_dir = NULL, batch_size = NULL,
   download = TRUE, shuffle_files = FALSE, as_supervised = FALSE,
   decoders = NULL, builder_kwargs = NULL,
   download_and_prepare_kwargs = NULL, as_dataset_kwargs = NULL,
-  try_gcs = FALSE)
+  try_gcs = FALSE, ...)
 }
 \arguments{
 \item{name}{\code{str}, the registered name of the \code{DatasetBuilder} (the snake case


### PR DESCRIPTION
Looks like `in_memory` was deprecated; https://github.com/tensorflow/datasets/commit/1b66d2c685cc8f0b8b33d7ef23cb6db70f01ff68#diff-80f21f81672ca92d449477a6d69d2c76

Currently hitting:

```
Error in py_call_impl(callable, dots$args, dots$keywords): TypeError: load() got an unexpected keyword argument 'in_memory'

Detailed traceback: 
  File "/home/rstudio/.local/lib/python3.6/site-packages/tensorflow_datasets/core/api_utils.py", line 53, in disallow_positional_args_dec
    return fn(*args, **kwargs)

Traceback:

1. tfds_load("mnist", in_memory = TRUE)
2. tfds$load(name = name, split = split, data_dir = data_dir, batch_size = batch_size, 
 .     in_memory = in_memory, download = download, shuffle_files = shuffle_files, 
 .     as_supervised = as_supervised, decoders = decoders, builder_kwargs = builder_kwargs, 
 .     download_and_prepare_kwargs = download_and_prepare_kwargs, 
 .     as_dataset_kwargs = as_dataset_kwargs, try_gcs = try_gcs, 
 .     with_info = TRUE)
3. py_call_impl(callable, dots$args, dots$keywords)
```